### PR TITLE
Add more NatSpec comments

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -65,8 +65,9 @@ abstract contract BaseStrategy is PausableUpgradeable {
         uint256 amount;
     }
 
-    /// @dev Initializer for the BaseStrategy
-    /// @notice Make sure to call it from your specific Strategy
+    /// @notice Initializes BaseStrategy. Can only be called once. 
+    ///         Make sure to call it from the initializer of the derived strategy.
+    /// @param _vault Address of the vault that the strategy reports to.
     function __BaseStrategy_init(address _vault) public initializer whenNotPaused {
         require(_vault != address(0), "Address 0");
         __Pausable_init();
@@ -80,63 +81,76 @@ abstract contract BaseStrategy is PausableUpgradeable {
 
     // ===== Modifiers =====
 
+    /// @notice Checks whether a call is from governance. 
     /// @dev For functions that only the governance should be able to call 
-    /// @notice most of the time setting setters, or to rescue / sweep funds
+    ///      Most of the time setting setters, or to rescue/sweep funds
     function _onlyGovernance() internal view {
         require(msg.sender == governance(), "onlyGovernance");
     }
 
+    /// @notice Checks whether a call is from strategist or governance. 
     /// @dev For functions that only known bening entities should call
     function _onlyGovernanceOrStrategist() internal view {
         require(msg.sender == strategist() || msg.sender == governance(), "onlyGovernanceOrStrategist");
     }
 
+    /// @notice Checks whether a call is from keeper or governance. 
     /// @dev For functions that only known bening entities should call
     function _onlyAuthorizedActors() internal view {
         require(msg.sender == keeper() || msg.sender == governance(), "onlyAuthorizedActors");
     }
 
+    /// @notice Checks whether a call is from the vault. 
     /// @dev For functions that only the vault should use
     function _onlyVault() internal view {
         require(msg.sender == vault, "onlyVault");
     }
 
-    /// @dev Modifier used to check if the function is being called by a bening entity
+    /// @notice Checks whether a call is from keeper, governance or the vault. 
+    /// @dev Modifier used to check if the function is being called by a benign entity
     function _onlyAuthorizedActorsOrVault() internal view {
         require(msg.sender == keeper() || msg.sender == governance() || msg.sender == vault, "onlyAuthorizedActorsOrVault");
     }
 
+    /// @notice Checks whether a call is from guardian or governance.
     /// @dev Modifier used exclusively for pausing
     function _onlyAuthorizedPausers() internal view {
         require(msg.sender == guardian() || msg.sender == governance(), "onlyPausers");
     }
 
     /// ===== View Functions =====
-    /// @dev Returns the version of the BaseStrategy 
+    /// @notice Used to track the deployed version of BaseStrategy.
+    /// @return Current version of the contract.
     function baseStrategyVersion() external pure returns (string memory) {
         return "1.5";
     }
 
-    /// @notice Get the balance of want held idle in the Strategy
-    /// @notice public because used internally for accounting
+    /// @notice Gives the balance of want held idle in the Strategy.
+    /// @dev Public because used internally for accounting
+    /// @return Balance of want held idle in the strategy.
     function balanceOfWant() public view returns (uint256) {
         return IERC20Upgradeable(want).balanceOf(address(this));
     }
 
-    /// @notice Get the total balance of want realized in the strategy, whether idle or active in Strategy positions.
+    /// @notice Gives the total balance of want managed by the strategy.
+    ///         This includes all want deposited to active strategy positions as well as any idle want in the strategy.
+    /// @return Total balance of want managed by the strategy.
     function balanceOf() external view returns (uint256) {
         return balanceOfWant().add(balanceOfPool());
     }
 
-    /// @dev Returns the boolean that tells whether this strategy is supposed to be tended or not
-    /// @notice This is basically a constant, the harvest bots checks if this is true and in that case will call `tend`
+    /// @notice Tells whether the strategy is supposed to be tended.
+    /// @dev This is usually a constant. The harvest keeper would only call `tend` if this is true.
+    /// @return Boolean indicating whether strategy is supposed to be tended or not.
     function isTendable() external pure returns (bool) {
         return _isTendable();
     }
 
     function _isTendable() internal virtual pure returns (bool);
 
-    /// @dev Used to verify if a token can be transfered / sweeped (as it's not part of the strategy)
+    /// @notice Checks whether a token is a protected token.
+    ///         Protected tokens are managed by the strategy and can't be transfered/sweeped.
+    /// @return Boolean indicating whether the token is a protected token.
     function isProtectedToken(address token) public view returns (bool) {
         require(token != address(0), "Address 0");
 
@@ -149,31 +163,36 @@ abstract contract BaseStrategy is PausableUpgradeable {
         return false;
     }
 
-    /// @dev gets the governance
+    /// @notice Fetches the governance address from the vault.
+    /// @return The governance address.
     function governance() public view returns (address) {
         return IVault(vault).governance();
     }
 
-    /// @dev gets the strategist
+    /// @notice Fetches the strategist address from the vault.
+    /// @return The strategist address.
     function strategist() public view returns (address) {
         return IVault(vault).strategist();
     }
 
-    /// @dev gets the keeper
+    /// @notice Fetches the keeper address from the vault.
+    /// @return The keeper address.
     function keeper() public view returns (address) {
         return IVault(vault).keeper();
     }
 
-    /// @dev gets the guardian
+    /// @notice Fetches the guardian address from the vault.
+    /// @return The guardian address.
     function guardian() public view returns (address) {
         return IVault(vault).guardian();
     }
 
     /// ===== Permissioned Actions: Governance =====
     
-    /// @dev Allows to change withdrawalMaxDeviationThreshold
-    /// @notice Anytime a withdrawal is done, the vault uses the current assets `vault.balance()` to calculate the value of each share
-    /// @notice When the strategy calls `_withdraw` it uses this variable as a slippage check against the actual funds withdrawn
+    /// @notice Sets the max withdrawal deviation (percentage loss) that is acceptable to the strategy.
+    ///         This can only be called by governance.
+    /// @dev This is used as a slippage check against the actual funds withdrawn from strategy positions.
+    ///      See `withdraw`.
     function setWithdrawalMaxDeviationThreshold(uint256 _threshold) external {
         _onlyGovernance();
         require(_threshold <= MAX_BPS, "_threshold should be <= MAX_BPS");
@@ -181,13 +200,18 @@ abstract contract BaseStrategy is PausableUpgradeable {
         emit SetWithdrawalMaxDeviationThreshold(_threshold);
     }
 
-    /// @dev Calls deposit, see below
+    /// @notice Deposits any idle want in the strategy into positions.
+    ///         This can be called by either the vault, keeper or governance.
+    ///         Note that deposits don't work when the strategy is paused. 
+    /// @dev See `deposit`.
     function earn() external whenNotPaused {
         deposit();
     }
 
-    /// @dev Causes the strategy to `_deposit` the idle want sitting in the strategy
-    /// @notice Is basically the same as tend, except without custom code for it 
+    /// @notice Deposits any idle want in the strategy into positions.
+    ///         This can be called by either the vault, keeper or governance.
+    ///         Note that deposits don't work when the strategy is paused. 
+    /// @dev Is basically the same as tend, except without custom code for it 
     function deposit() public whenNotPaused {
         _onlyAuthorizedActorsOrVault();
         uint256 _amount = IERC20Upgradeable(want).balanceOf(address(this));
@@ -198,12 +222,14 @@ abstract contract BaseStrategy is PausableUpgradeable {
 
     // ===== Permissioned Actions: Vault =====
 
-    /// @notice Vault-only function to Withdraw partial funds, normally used with a vault withdrawal
-    /// @notice This can be called even when paused, and strategist can trigger this
-    /// @notice the idea is that this can allow recovery of funds back to the strategy faster
-    /// @notice the risk is that if _withdrawAll causes a loss this can be triggered
-    /// @notice however the loss could only be triggered once (just like if governance called)
-    /// @notice as pausing the strats would prevent earning again
+    /// @notice Withdraw all funds from the strategy to the vault, unrolling all positions.
+    ///         This can only be called by the vault.
+    /// @dev This can be called even when paused, and strategist can trigger this via the vault.
+    ///      The idea is that this can allow recovery of funds back to the strategy faster.
+    ///      The risk is that if _withdrawAll causes a loss, this can be triggered.
+    ///      However the loss could only be triggered once (just like if governance called)
+    ///      as pausing the strats would prevent earning again.
+    /// @return balance Amount of want transferred to the vault.
     function withdrawToVault() external returns (uint256 balance) {
         _onlyVault();
 
@@ -215,8 +241,12 @@ abstract contract BaseStrategy is PausableUpgradeable {
         return balance;
     }
 
-    /// @notice Withdraw partial funds from the strategy, unrolling from strategy positions as necessary
-    /// @dev If it fails to recover sufficient funds (defined by withdrawalMaxDeviationThreshold), the withdrawal should fail so that this unexpected behavior can be investigated
+    /// @notice Withdraw partial funds from the strategy to the vault, unrolling from strategy positions as necessary.
+    ///         This can only be called by the vault.
+    ///         Note that withdraws don't work when the strategy is paused. 
+    /// @dev If the strategy fails to recover sufficient funds (defined by `withdrawalMaxDeviationThreshold`), 
+    ///      the withdrawal would fail so that this unexpected behavior can be investigated.
+    /// @param _amount Amount of funds required to be withdrawn.
     function withdraw(uint256 _amount) external whenNotPaused {
         _onlyVault();
         require(_amount != 0, "Amount 0");
@@ -241,14 +271,16 @@ abstract contract BaseStrategy is PausableUpgradeable {
         _transferToVault(_toWithdraw);
     }
 
-    // e.g. airdrop or donation
     // Discussion: https://discord.com/channels/785315893960900629/837083557557305375
-    /// @dev The counterpart to _processExtraToken
-    /// @dev Allows to emit the non protected tokens
-    /// @notice this is for the tokens you didn't expect the strat to receive
-    /// @notice instead of sweeping them, just emit so it saves time while offering security guarantees
-    /// @notice This is not a rug vector as it can't use protected tokens
-    /// @notice No address(0) check because _onlyNotProtectedTokens does it
+    /// @notice Sends balance of any extra token earned by the strategy (from airdrops, donations etc.) to the vault.
+    ///         The `_token` should be different from any tokens managed by the strategy.
+    ///         This can only be called by the vault.
+    /// @dev This is a counterpart to `_processExtraToken`.
+    ///      This is for tokens that the strategy didn't expect to receive. Instead of sweeping, we can directly
+    ///      emit them via the badgerTree. This saves time while offering security guarantees.
+    ///      No address(0) check because _onlyNotProtectedTokens does it.
+    ///      This is not a rug vector as it can't use protected tokens.
+    /// @param _token Address of the token to be emitted.
     function emitNonProtectedToken(address _token) external {
         _onlyVault();
         _onlyNotProtectedTokens(_token);
@@ -256,9 +288,12 @@ abstract contract BaseStrategy is PausableUpgradeable {
         IVault(vault).reportAdditionalToken(_token);
     }
 
-    /// @dev Withdraw the non protected token, used for sweeping it out
-    /// @notice this is the version that just sends the assets to governance
-    /// @notice No address(0) check because _onlyNotProtectedTokens does it
+    /// @notice Withdraw the balance of a non-protected token to the vault.
+    ///         This can only be called by the vault.
+    /// @dev Should only be used in an emergency to sweep any asset.
+    ///      This is the version that sends the assets to governance.
+    ///      No address(0) check because _onlyNotProtectedTokens does it.
+    /// @param _asset Address of the token to be withdrawn.
     function withdrawOther(address _asset) external {
         _onlyVault();
         _onlyNotProtectedTokens(_asset);
@@ -267,15 +302,16 @@ abstract contract BaseStrategy is PausableUpgradeable {
 
     /// ===== Permissioned Actions: Authoized Contract Pausers =====
 
-    /// @dev Pause the contract
-    /// @notice Check the `onlyWhenPaused` modifier for functionality that is blocked when pausing
+    /// @notice Pauses the strategy.
+    ///         This can be called by either guardian or governance.
+    /// @dev Check the `onlyWhenPaused` modifier for functionality that is blocked when pausing
     function pause() external {
         _onlyAuthorizedPausers();
         _pause();
     }
 
-    /// @dev Unpause the contract
-    /// @notice while a guardian can also pause, only governance (multisig with timelock) can unpause
+    /// @notice Unpauses the strategy.
+    ///         This can only be called by governance (usually a multisig behind a timelock).
     function unpause() external {
         _onlyGovernance();
         _unpause();
@@ -283,29 +319,33 @@ abstract contract BaseStrategy is PausableUpgradeable {
 
     /// ===== Internal Helper Functions =====
 
-    /// @dev function to transfer specific amount of want to vault from strategy
-    /// @notice strategy should have idle funds >= _amount for this to happen
-    /// @param _amount: the amount of want token to transfer to vault
+    /// @notice Transfers `_amount` of want to the vault.
+    /// @dev Strategy should have idle funds >= `_amount`.
+    /// @param _amount Amount of want to be transferred to the vault.
     function _transferToVault(uint256 _amount) internal {
         if (_amount > 0) {
             IERC20Upgradeable(want).safeTransfer(vault, _amount);
         }
     }
 
-    /// @dev function to report harvest to vault
-    /// @param _harvestedAmount: amount of want token autocompounded during harvest
+    /// @notice Report an harvest to the vault.
+    /// @param _harvestedAmount Amount of want token autocompounded during harvest.
     function _reportToVault(
         uint256 _harvestedAmount
     ) internal {
         IVault(vault).reportHarvest(_harvestedAmount);
     }
 
-    /// @dev Report additional token income to the Vault, handles fees and sends directly to tree
-    /// @notice This is how you emit tokens in V1.5
-    /// @notice After calling this function, the tokens are gone, sent to fee receivers and badgerTree
-    /// @notice This is a rug vector as it allows to move funds to the tree
-    /// @notice for this reason I highly recommend you verify the tree is the badgerTree from the registry
-    /// @notice also check for this to be used exclusively on harvest, exclusively on protectedTokens
+    /// @notice Sends balance of an additional token (eg. reward token) earned by the strategy to the vault.
+    ///         This should usally be called exclusively on protectedTokens.
+    ///         Calls `Vault.reportAdditionalToken` to process fees and forward amount to badgerTree to be emitted.
+    /// @dev This is how you emit tokens in V1.5
+    ///      After calling this function, the tokens are gone, sent to fee receivers and badgerTree
+    ///      This is a rug vector as it allows to move funds to the tree
+    ///      For this reason, it is recommended to verify the tree is the badgerTree from the registry
+    ///      and also check for this to be used exclusively on harvest, exclusively on protectedTokens.
+    /// @param _token Address of the token to be emitted.
+    /// @param _amount Amount of token to transfer to vault.
     function _processExtraToken(address _token, uint256 _amount) internal {
         require(_token != want, "Not want, use _reportToVault");
         require(_token != address(0), "Address 0");
@@ -323,59 +363,72 @@ abstract contract BaseStrategy is PausableUpgradeable {
 
     // ===== Abstract Functions: To be implemented by specific Strategies =====
 
-    /// @dev Internal deposit logic to be implemented by Stratgies
-    /// @param _want: the amount of want token to be deposited into the strategy
+    /// @dev Internal deposit logic to be implemented by a derived stratgy.
+    /// @param _want Amount of want token to be deposited into the strategy.
     function _deposit(uint256 _want) internal virtual;
 
-    /// @notice Specify tokens used in yield process, should not be available to withdraw via withdrawOther()
-    /// @param _asset: address of asset
+    /// @notice Checks if a token is not used in yield process.
+    /// @param _asset Address of token.
     function _onlyNotProtectedTokens(address _asset) internal view {
         require(!isProtectedToken(_asset), "_onlyNotProtectedTokens");
     }
 
-    /// @dev Gives the list of protected tokens
-    /// @return array of protected tokens
+    /// @notice Gives the list of protected tokens.
+    /// @return Array of protected tokens.
     function getProtectedTokens() public view virtual returns (address[] memory);
 
-    /// @dev Internal logic for strategy migration. Should exit positions as efficiently as possible
+    /// @dev Internal logic for strategy migration. Should exit positions as efficiently as possible.
     function _withdrawAll() internal virtual;
 
     /// @dev Internal logic for partial withdrawals. Should exit positions as efficiently as possible.
-    /// @dev The withdraw() function shell automatically uses idle want in the strategy before attempting to withdraw more using this
-    /// @param _amount: the amount of want token to be withdrawm from the strategy
-    /// @return withdrawn amount from the strategy
+    ///      Should idally use idle want in the strategy before attempting to exit strategy positions.
+    /// @param _amount Amount of want token to be withdrawm from the strategy.
+    /// @return Withdrawn amount from the strategy.
     function _withdrawSome(uint256 _amount) internal virtual returns (uint256);
 
-    /// @dev Realize returns from positions
-    /// @dev Returns can be reinvested into positions, or distributed in another fashion
-    /// @return harvested : total amount harvested for each token, returned as a TokenAmount
+    /// @notice Realize returns from strategy positions.
+    ///         This can only be called by keeper or governance.
+    ///         Note that harvests don't work when the strategy is paused. 
+    /// @dev Returns can be reinvested into positions, or distributed in another fashion.
+    /// @return harvested An array of `TokenAmount` containing the address and amount harvested for each token.
     function harvest() external whenNotPaused returns (TokenAmount[] memory harvested) {
         _onlyAuthorizedActors();
         return _harvest();
     }
 
+    /// @dev Virtual function that should be overriden with the logic for harvest. 
+    ///      Should report any want or non-want gains to the vault.
+    ///      Also see `harvest`.
     function _harvest() internal virtual returns (TokenAmount[] memory harvested);
 
+    /// @notice Tend strategy positions as needed to maximize returns.
+    ///         This can only be called by keeper or governance.
+    ///         Note that tend doesn't work when the strategy is paused. 
+    /// @dev Is only called by the keeper when `isTendable` is true.
+    /// @return tended An array of `TokenAmount` containing the address and amount tended for each token.
     function tend() external whenNotPaused returns (TokenAmount[] memory tended) {
         _onlyAuthorizedActors();
 
         return _tend();
     }
 
+    /// @dev Virtual function that should be overriden with the logic for tending. 
+    ///      Also see `tend`.
     function _tend() internal virtual returns (TokenAmount[] memory tended);
 
 
-    /// @dev User-friendly name for this strategy for purposes of convenient reading
-    /// @return Name of the strategy
+    /// @notice Fetches the name of the strategy.
+    /// @dev Should be user-friendly and easy to read.
+    /// @return Name of the strategy.
     function getName() external pure virtual returns (string memory);
 
-    /// @dev Balance of want currently held in strategy positions
-    /// @return balance of want held in strategy positions
+    /// @notice Gives the balance of want held in strategy positions.
+    /// @return Balance of want held in strategy positions.
     function balanceOfPool() public view virtual returns (uint256);
 
-    /// @dev Calculate the total amount of rewards accured.
-    /// @notice if there are multiple reward tokens this function should take all of them into account
-    /// @return rewards - the TokenAmount of rewards accured
+    /// @notice Gives the total amount of pending rewards accured for each token.
+    /// @dev Should take into account all reward tokens.
+    /// @return rewards An array of `TokenAmount` containing the address and amount of each reward token.
     function balanceOfRewards() external view virtual returns (TokenAmount[] memory rewards);
 
     uint256[49] private __gap;

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -57,7 +57,7 @@ abstract contract BaseStrategy is PausableUpgradeable {
 
     // NOTE: You have to set autoCompoundRatio in the initializer of your strategy
 
-    event SetWithdrawalMaxDeviationThreshold(uint256 nawMaxDeviationThreshold);
+    event SetWithdrawalMaxDeviationThreshold(uint256 newMaxDeviationThreshold);
 
     // Return value for harvest, tend and balanceOfRewards
     struct TokenAmount {

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -588,10 +588,11 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         IStrategy(strategy).withdrawToVault();
     }
 
-    /// @notice Sends balance of any extra token earned by the strategy (from airdrops etc.) to the badgerTree for emissions.
+    /// @notice Sends balance of any extra token earned by the strategy (from airdrops, donations etc.) 
+    ///         to the badgerTree for emissions.
     ///         The `_token` should be different from any tokens managed by the strategy.
     ///         This can only be called by either strategist or governance.
-    /// @dev See `BaseStrategy::emitNonProtectedToken` for details.
+    /// @dev See `BaseStrategy.emitNonProtectedToken` for details.
     /// @param _token Address of the token to be emitted.
     function emitNonProtectedToken(address _token) external {
         _onlyGovernanceOrStrategist();

--- a/docs/BaseStrategy.md
+++ b/docs/BaseStrategy.md
@@ -1,0 +1,369 @@
+## `BaseStrategy`
+
+
+
+
+
+
+### `__BaseStrategy_init(address _vault)` (public)
+
+Initializes BaseStrategy. Can only be called once. 
+        Make sure to call it from the initializer of the derived strategy.
+
+
+
+
+### `_onlyGovernance()` (internal)
+
+Checks whether a call is from governance. 
+
+
+For functions that only the governance should be able to call 
+     Most of the time setting setters, or to rescue/sweep funds
+
+### `_onlyGovernanceOrStrategist()` (internal)
+
+Checks whether a call is from strategist or governance. 
+
+
+For functions that only known bening entities should call
+
+### `_onlyAuthorizedActors()` (internal)
+
+Checks whether a call is from keeper or governance. 
+
+
+For functions that only known bening entities should call
+
+### `_onlyVault()` (internal)
+
+Checks whether a call is from the vault. 
+
+
+For functions that only the vault should use
+
+### `_onlyAuthorizedActorsOrVault()` (internal)
+
+Checks whether a call is from keeper, governance or the vault. 
+
+
+Modifier used to check if the function is being called by a benign entity
+
+### `_onlyAuthorizedPausers()` (internal)
+
+Checks whether a call is from guardian or governance.
+
+
+Modifier used exclusively for pausing
+
+### `baseStrategyVersion() → string` (external)
+
+===== View Functions =====
+Used to track the deployed version of BaseStrategy.
+
+
+
+
+### `balanceOfWant() → uint256` (public)
+
+Gives the balance of want held idle in the Strategy.
+
+
+Public because used internally for accounting
+
+
+### `balanceOf() → uint256` (external)
+
+Gives the total balance of want managed by the strategy.
+        This includes all want deposited to active strategy positions as well as any idle want in the strategy.
+
+
+
+
+### `isTendable() → bool` (external)
+
+Tells whether the strategy is supposed to be tended.
+
+
+This is usually a constant. The harvest keeper would only call `tend` if this is true.
+
+
+### `_isTendable() → bool` (internal)
+
+
+
+
+
+### `isProtectedToken(address token) → bool` (public)
+
+Checks whether a token is a protected token.
+        Protected tokens are managed by the strategy and can't be transfered/sweeped.
+
+
+
+
+### `governance() → address` (public)
+
+Fetches the governance address from the vault.
+
+
+
+
+### `strategist() → address` (public)
+
+Fetches the strategist address from the vault.
+
+
+
+
+### `keeper() → address` (public)
+
+Fetches the keeper address from the vault.
+
+
+
+
+### `guardian() → address` (public)
+
+Fetches the guardian address from the vault.
+
+
+
+
+### `setWithdrawalMaxDeviationThreshold(uint256 _threshold)` (external)
+
+Sets the max withdrawal deviation (percentage loss) that is acceptable to the strategy.
+        This can only be called by governance.
+
+
+This is used as a slippage check against the actual funds withdrawn from strategy positions.
+     See `withdraw`.
+
+### `earn()` (external)
+
+Deposits any idle want in the strategy into positions.
+        This can be called by either the vault, keeper or governance.
+        Note that deposits don't work when the strategy is paused. 
+
+
+See `deposit`.
+
+### `deposit()` (public)
+
+Deposits any idle want in the strategy into positions.
+        This can be called by either the vault, keeper or governance.
+        Note that deposits don't work when the strategy is paused. 
+
+
+Is basically the same as tend, except without custom code for it
+
+### `withdrawToVault() → uint256 balance` (external)
+
+Withdraw all funds from the strategy to the vault, unrolling all positions.
+        This can only be called by the vault.
+
+
+This can be called even when paused, and strategist can trigger this via the vault.
+     The idea is that this can allow recovery of funds back to the strategy faster.
+     The risk is that if _withdrawAll causes a loss, this can be triggered.
+     However the loss could only be triggered once (just like if governance called)
+     as pausing the strats would prevent earning again.
+
+
+### `withdraw(uint256 _amount)` (external)
+
+Withdraw partial funds from the strategy to the vault, unrolling from strategy positions as necessary.
+        This can only be called by the vault.
+        Note that withdraws don't work when the strategy is paused. 
+
+
+If the strategy fails to recover sufficient funds (defined by `withdrawalMaxDeviationThreshold`), 
+     the withdrawal would fail so that this unexpected behavior can be investigated.
+
+
+### `emitNonProtectedToken(address _token)` (external)
+
+Sends balance of any extra token earned by the strategy (from airdrops, donations etc.) to the vault.
+        The `_token` should be different from any tokens managed by the strategy.
+        This can only be called by the vault.
+
+
+This is a counterpart to `_processExtraToken`.
+     This is for tokens that the strategy didn't expect to receive. Instead of sweeping, we can directly
+     emit them via the badgerTree. This saves time while offering security guarantees.
+     No address(0) check because _onlyNotProtectedTokens does it.
+     This is not a rug vector as it can't use protected tokens.
+
+
+### `withdrawOther(address _asset)` (external)
+
+Withdraw the balance of a non-protected token to the vault.
+        This can only be called by the vault.
+
+
+Should only be used in an emergency to sweep any asset.
+     This is the version that sends the assets to governance.
+     No address(0) check because _onlyNotProtectedTokens does it.
+
+
+### `pause()` (external)
+
+Pauses the strategy.
+        This can be called by either guardian or governance.
+
+
+Check the `onlyWhenPaused` modifier for functionality that is blocked when pausing
+
+### `unpause()` (external)
+
+Unpauses the strategy.
+        This can only be called by governance (usually a multisig behind a timelock).
+
+
+
+### `_transferToVault(uint256 _amount)` (internal)
+
+Transfers `_amount` of want to the vault.
+
+
+Strategy should have idle funds >= `_amount`.
+
+
+### `_reportToVault(uint256 _harvestedAmount)` (internal)
+
+Report an harvest to the vault.
+
+
+
+
+### `_processExtraToken(address _token, uint256 _amount)` (internal)
+
+Sends balance of an additional token (eg. reward token) earned by the strategy to the vault.
+        This should usally be called exclusively on protectedTokens.
+        Calls `Vault.reportAdditionalToken` to process fees and forward amount to badgerTree to be emitted.
+
+
+This is how you emit tokens in V1.5
+     After calling this function, the tokens are gone, sent to fee receivers and badgerTree
+     This is a rug vector as it allows to move funds to the tree
+     For this reason, it is recommended to verify the tree is the badgerTree from the registry
+     and also check for this to be used exclusively on harvest, exclusively on protectedTokens.
+
+
+### `_diff(uint256 a, uint256 b) → uint256` (internal)
+
+Utility function to diff two numbers, expects higher value in first position
+
+
+
+### `_deposit(uint256 _want)` (internal)
+
+
+
+Internal deposit logic to be implemented by a derived stratgy.
+
+
+### `_onlyNotProtectedTokens(address _asset)` (internal)
+
+Checks if a token is not used in yield process.
+
+
+
+
+### `getProtectedTokens() → address[]` (public)
+
+Gives the list of protected tokens.
+
+
+
+
+### `_withdrawAll()` (internal)
+
+
+
+Internal logic for strategy migration. Should exit positions as efficiently as possible.
+
+### `_withdrawSome(uint256 _amount) → uint256` (internal)
+
+
+
+Internal logic for partial withdrawals. Should exit positions as efficiently as possible.
+     Should idally use idle want in the strategy before attempting to exit strategy positions.
+
+
+### `harvest() → struct BaseStrategy.TokenAmount[] harvested` (external)
+
+Realize returns from strategy positions.
+        This can only be called by keeper or governance.
+        Note that harvests don't work when the strategy is paused. 
+
+
+Returns can be reinvested into positions, or distributed in another fashion.
+
+
+### `_harvest() → struct BaseStrategy.TokenAmount[] harvested` (internal)
+
+
+
+Virtual function that should be overriden with the logic for harvest. 
+     Should report any want or non-want gains to the vault.
+     Also see `harvest`.
+
+### `tend() → struct BaseStrategy.TokenAmount[] tended` (external)
+
+Tend strategy positions as needed to maximize returns.
+        This can only be called by keeper or governance.
+        Note that tend doesn't work when the strategy is paused. 
+
+
+Is only called by the keeper when `isTendable` is true.
+
+
+### `_tend() → struct BaseStrategy.TokenAmount[] tended` (internal)
+
+
+
+Virtual function that should be overriden with the logic for tending. 
+     Also see `tend`.
+
+### `getName() → string` (external)
+
+Fetches the name of the strategy.
+
+
+Should be user-friendly and easy to read.
+
+
+### `balanceOfPool() → uint256` (public)
+
+Gives the balance of want held in strategy positions.
+
+
+
+
+### `balanceOfRewards() → struct BaseStrategy.TokenAmount[] rewards` (external)
+
+Gives the total amount of pending rewards accured for each token.
+
+
+Should take into account all reward tokens.
+
+
+
+### `SetWithdrawalMaxDeviationThreshold(uint256 newMaxDeviationThreshold)`
+
+
+
+
+
+
+### `TokenAmount`
+
+
+address token
+
+
+uint256 amount
+
+
+

--- a/docs/Vault.md
+++ b/docs/Vault.md
@@ -1,0 +1,504 @@
+## `Vault`
+
+
+
+
+
+
+### `initialize(address _token, address _governance, address _keeper, address _guardian, address _treasury, address _strategist, address _badgerTree, string _name, string _symbol, uint256[4] _feeConfig)` (public)
+
+Initializes the Sett. Can only be called once, ideally when the contract is deployed.
+
+
+
+
+### `_onlyAuthorizedPausers()` (internal)
+
+Checks whether a call is from guardian or governance.
+
+
+
+### `_onlyStrategy()` (internal)
+
+Checks whether a call is from the strategy.
+
+
+
+### `version() → string` (external)
+
+Used to track the deployed version of the contract.
+
+
+
+
+### `getPricePerFullShare() → uint256` (public)
+
+Gives the price for a single Sett share.
+
+
+Sett starts with a price per share of 1.
+
+
+### `balance() → uint256` (public)
+
+Gives the total balance of the underlying token within the sett and strategy system.
+
+
+
+
+### `available() → uint256` (public)
+
+Defines how much of the Setts' underlying is available for strategy to borrow.
+
+
+
+
+### `deposit(uint256 _amount)` (external)
+
+Deposits `_amount` tokens, issuing shares. 
+        Note that deposits are not accepted when the Sett is paused or when `pausedDeposit` is true. 
+
+
+See `_depositFor` for details on how deposit is implemented. 
+
+
+### `deposit(uint256 _amount, bytes32[] proof)` (external)
+
+Deposits `_amount` tokens, issuing shares. 
+        Checks the guestlist to verify that the calling account is authorized to make a deposit for the specified `_amount`.
+        Note that deposits are not accepted when the Sett is paused or when `pausedDeposit` is true. 
+
+
+See `_depositForWithAuthorization` for details on guestlist authorization.
+
+
+### `depositAll()` (external)
+
+Deposits all tokens, issuing shares. 
+        Note that deposits are not accepted when the Sett is paused or when `pausedDeposit` is true. 
+
+
+See `_depositFor` for details on how deposit is implemented.
+
+### `depositAll(bytes32[] proof)` (external)
+
+Deposits all tokens, issuing shares. 
+        Checks the guestlist to verify that the calling is authorized to make a full deposit.
+        Note that deposits are not accepted when the Sett is paused or when `pausedDeposit` is true. 
+
+
+See `_depositForWithAuthorization` for details on guestlist authorization.
+
+
+### `depositFor(address _recipient, uint256 _amount)` (external)
+
+Deposits `_amount` tokens, issuing shares to `recipient`. 
+        Note that deposits are not accepted when the Sett is paused or when `pausedDeposit` is true. 
+
+
+See `_depositFor` for details on how deposit is implemented. 
+
+
+### `depositFor(address _recipient, uint256 _amount, bytes32[] proof)` (external)
+
+Deposits `_amount` tokens, issuing shares to `recipient`. 
+        Checks the guestlist to verify that `recipient` is authorized to make a deposit for the specified `_amount`.
+        Note that deposits are not accepted when the Sett is paused or when `pausedDeposit` is true. 
+
+
+See `_depositForWithAuthorization` for details on guestlist authorization.
+
+
+### `withdraw(uint256 _shares)` (external)
+
+Redeems `_shares` for an appropriate amount of tokens.
+        Note that withdrawals are not processed when the Sett is paused. 
+
+
+See `_withdraw` for details on how withdrawals are processed.
+
+
+### `withdrawAll()` (external)
+
+Redeems all shares, issuing an appropriate amount of tokens. 
+        Note that withdrawals are not processed when the Sett is paused. 
+
+
+See `_withdraw` for details on how withdrawals are processed.
+
+### `reportHarvest(uint256 _harvestedAmount)` (external)
+
+Used by the strategy to report a harvest to the sett.
+        Issues shares for the strategist and treasury based on the performance fees and harvested amount. 
+        Issues shares for the treasury based on the management fee and the time elapsed since last harvest. 
+        Updates harvest variables for on-chain APR tracking.
+        This can only be called by the strategy.
+
+
+This impliclty trusts that the strategy reports the correct amount.
+     Pausing on this function happens at the strategy level.
+
+
+### `reportAdditionalToken(address _token)` (external)
+
+Used by the strategy to report harvest of additional tokens to the sett.
+        Charges perfromance fees on the additional tokens and transfers fees to treasury and strategist. 
+        The remaining amount is sent to badgerTree for emissions.
+        Updates harvest variables for on-chain APR tracking.
+        This can only be called by the strategy.
+
+
+This function is called after the strategy sends the additional tokens to the sett.
+     Pausing on this function happens at the strategy level.
+
+
+### `setTreasury(address _treasury)` (external)
+
+Changes the treasury address.
+        Treasury is recipient of management and governance performance fees.
+        This can only be called by governance.
+        Note that this can only be called when sett is not paused.
+
+
+
+
+### `setStrategy(address _strategy)` (external)
+
+Changes the strategy address.
+        This can only be called by governance.
+        Note that this can only be called when sett is not paused.
+
+
+This is a rug vector, pay extremely close attention to the next strategy being set.
+     Changing the strategy should happen only via timelock.
+     This function must not be callable when the sett is paused as this would force depositors into a strategy they may not want to use.
+
+
+### `setMaxWithdrawalFee(uint256 _fees)` (external)
+
+Sets the max withdrawal fee that can be charged by the Sett.
+        This can only be called by governance.
+
+
+The input `_fees` should be less than the `WITHDRAWAL_FEE_HARD_CAP` hard-cap.
+
+
+### `setMaxPerformanceFee(uint256 _fees)` (external)
+
+Sets the max performance fee that can be charged by the Sett.
+        This can only be called by governance.
+
+
+The input `_fees` should be less than the `PERFORMANCE_FEE_HARD_CAP` hard-cap.
+
+
+### `setMaxManagementFee(uint256 _fees)` (external)
+
+Sets the max management fee that can be charged by the Sett.
+        This can only be called by governance.
+
+
+The input `_fees` should be less than the `MANAGEMENT_FEE_HARD_CAP` hard-cap.
+
+
+### `setGuardian(address _guardian)` (external)
+
+Changes the guardian address.
+        Guardian is an authorized actor that can pause the sett in case of an emergency.
+        This can only be called by governance.
+
+
+
+
+### `setToEarnBps(uint256 _newToEarnBps)` (external)
+
+Sets the fraction of sett balance (in basis points) that the strategy can borrow.
+        This can be called by either governance or strategist.
+        Note that this can only be called when the sett is not paused.
+
+
+
+
+### `setGuestList(address _guestList)` (external)
+
+Changes the guestlist address.
+        The guestList is used to gate or limit deposits. If no guestlist is set then anyone can deposit any amount.
+        This can be called by either governance or strategist.
+        Note that this can only be called when the sett is not paused.
+
+
+
+
+### `setWithdrawalFee(uint256 _withdrawalFee)` (external)
+
+Sets the withdrawal fee charged by the Sett.
+        The fee is taken at the time of withdrawals in the underlying token which is then used to issue new shares for the treasury.
+        The new withdrawal fee should be less than `maxWithdrawalFee`.
+        This can be called by either governance or strategist.
+
+
+See `_withdraw` to see how withdrawal fee is charged.
+
+
+### `setPerformanceFeeStrategist(uint256 _performanceFeeStrategist)` (external)
+
+Sets the performance fee taken by the strategist on the harvests.
+        The fee is taken at the time of harvest reporting for both the underlying token and additional tokens.
+        For the underlying token, the fee is used to issue new shares for the strategist.
+        The new performance fee should be less than `maxPerformanceFee`.
+        This can be called by either governance or strategist.
+
+
+See `reportHarvest` and `reportAdditionalToken` to see how performance fees are charged.
+
+
+### `setPerformanceFeeGovernance(uint256 _performanceFeeGovernance)` (external)
+
+Sets the performance fee taken by the treasury on the harvests.
+        The fee is taken at the time of harvest reporting for both the underlying token and additional tokens.
+        For the underlying token, the fee is used to issue new shares for the treasury.
+        The new performance fee should be less than `maxPerformanceFee`.
+        This can be called by either governance or strategist.
+
+
+See `reportHarvest` and `reportAdditionalToken` to see how performance fees are charged.
+
+
+### `setManagementFee(uint256 _fees)` (external)
+
+Sets the management fee taken by the treasury on the AUM in the sett.
+        The fee is calculated at the time of `reportHarvest` and is used to issue new shares for the treasury.
+        The new management fee should be less than `maxManagementFee`.
+        This can be called by either governance or strategist.
+
+
+See `_handleFees` to see how the management fee is calculated.
+
+
+### `withdrawToVault()` (external)
+
+Withdraws all funds from the strategy back to the sett.
+        This can be called by either governance or strategist.
+
+
+This calls `_withdrawAll` on the strategy and transfers the balance to the sett.
+
+### `emitNonProtectedToken(address _token)` (external)
+
+Sends balance of any extra token earned by the strategy (from airdrops etc.) to the badgerTree for emissions.
+        The `_token` should be different from any tokens managed by the strategy.
+        This can only be called by either strategist or governance.
+
+
+See `BaseStrategy::emitNonProtectedToken` for details.
+
+
+### `sweepExtraToken(address _token)` (external)
+
+Sweeps the balance of an extra token from the vault and strategy and sends it to governance.
+        The `_token` should be different from any tokens managed by the strategy.
+        This can only be called by either strategist or governance.
+
+
+Sweeping doesn't take any fee.
+
+
+### `earn()` (external)
+
+Deposits the available balance of the underlying token into the strategy.
+        The strategy then uses the amount for yield-generating activities.
+        This can be called by either the keeper or governance.
+        Note that earn cannot be called when deposits are paused.
+
+
+Pause is enforced at the Strategy level (this allows to still earn yield when the Vault is paused)
+
+### `pauseDeposits()` (external)
+
+Pauses only deposits.
+        This can be called by either guardian or governance.
+
+
+
+### `unpauseDeposits()` (external)
+
+Unpauses deposits.
+        This can only be called by governance.
+
+
+
+### `pause()` (external)
+
+Pauses everything.
+        This can be called by either guardian or governance.
+
+
+
+### `unpause()` (external)
+
+Unpauses everything
+        This can only be called by governance.
+
+
+
+### `_depositFor(address _recipient, uint256 _amount)` (internal)
+
+Deposits `_amount` tokens, issuing shares to `recipient`. 
+        Note that deposits are not accepted when `pausedDeposit` is true. 
+
+
+This is the actual deposit operation.
+     Deposits are based on the realized value of underlying assets between Sett & associated Strategy
+
+
+### `_depositWithAuthorization(uint256 _amount, bytes32[] proof)` (internal)
+
+
+
+See `_depositWithAuthorization`
+
+### `_depositForWithAuthorization(address _recipient, uint256 _amount, bytes32[] proof)` (internal)
+
+
+
+Verifies that `_recipient` is authorized to deposit `_amount` based on the guestlist.
+     See `_depositFor` for deposit details.
+
+### `_withdraw(uint256 _shares)` (internal)
+
+Redeems `_shares` for an appropriate amount of tokens.
+
+
+This is the actual withdraw operation.
+     Withdraws from strategy positions if sett doesn't contain enough tokens to process the withdrawal. 
+     Calculates withdrawal fees and issues corresponding shares to treasury.
+     No rebalance implementation for lower fees and faster swaps
+
+
+### `_calculateFee(uint256 amount, uint256 feeBps) → uint256` (internal)
+
+
+
+Helper funciton to calculate fees.
+
+
+### `_calculatePerformanceFee(uint256 _amount) → uint256, uint256` (internal)
+
+
+
+Helper funciton to calculate governance and strategist performance fees. Make sure to use it to get paid!
+
+
+### `_mintSharesFor(address recipient, uint256 _amount, uint256 _pool)` (internal)
+
+
+
+Helper funciton to issue shares to `recipient` based on an input `_amount` and `_pool` size.
+
+
+### `_handleFees(uint256 _harvestedAmount, uint256 harvestTime)` (internal)
+
+
+
+Helper function that issues shares based on performance and management fee when a harvest is reported.
+
+
+
+### `TreeDistribution(address token, uint256 amount, uint256 blockNumber, uint256 timestamp)`
+
+===== Events ====
+
+
+
+### `Harvested(address token, uint256 amount, uint256 blockNumber, uint256 timestamp)`
+
+
+
+
+
+### `SetTreasury(address newTreasury)`
+
+
+
+
+
+### `SetStrategy(address newStrategy)`
+
+
+
+
+
+### `SetToEarnBps(uint256 newEarnToBps)`
+
+
+
+
+
+### `SetMaxWithdrawalFee(uint256 newMaxWithdrawalFee)`
+
+
+
+
+
+### `SetMaxPerformanceFee(uint256 newMaxPerformanceFee)`
+
+
+
+
+
+### `SetMaxManagementFee(uint256 newMaxManagementFee)`
+
+
+
+
+
+### `SetGuardian(address newGuardian)`
+
+
+
+
+
+### `SetGuestList(address newGuestList)`
+
+
+
+
+
+### `SetWithdrawalFee(uint256 newWithdrawalFee)`
+
+
+
+
+
+### `SetPerformanceFeeStrategist(uint256 newPerformanceFeeStrategist)`
+
+
+
+
+
+### `SetPerformanceFeeGovernance(uint256 newPerformanceFeeGovernance)`
+
+
+
+
+
+### `SetManagementFee(uint256 newManagementFee)`
+
+
+
+
+
+### `PauseDeposits(address pausedBy)`
+
+
+
+
+
+### `UnpauseDeposits(address pausedBy)`
+
+
+
+
+
+
+

--- a/docs/Vault.md
+++ b/docs/Vault.md
@@ -285,12 +285,13 @@ This calls `_withdrawAll` on the strategy and transfers the balance to the sett.
 
 ### `emitNonProtectedToken(address _token)` (external)
 
-Sends balance of any extra token earned by the strategy (from airdrops etc.) to the badgerTree for emissions.
+Sends balance of any extra token earned by the strategy (from airdrops, donations etc.) 
+        to the badgerTree for emissions.
         The `_token` should be different from any tokens managed by the strategy.
         This can only be called by either strategist or governance.
 
 
-See `BaseStrategy::emitNonProtectedToken` for details.
+See `BaseStrategy.emitNonProtectedToken` for details.
 
 
 ### `sweepExtraToken(address _token)` (external)


### PR DESCRIPTION
This PR improves the documentation of external/public functions in `Vault.sol` and `BaseStrategy.sol` by adding more NatSpec comments.
These can be used to autogenerate markdown documentation using something like https://github.com/OpenZeppelin/solidity-docgen.