### PR TITLE
Fix fee events reported amounts

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -764,8 +764,8 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         // Process withdrawal fee
         if(_fee > 0) {
             address cachedTreasury = treasury;
-            _mintSharesFor(cachedTreasury, _fee, balance().sub(_fee));
-            emit WithdrawalFee(cachedTreasury, address(this), _fee, block.number, block.timestamp);
+            uint256 feeInShares = _mintSharesFor(cachedTreasury, _fee, balance().sub(_fee));
+            emit WithdrawalFee(cachedTreasury, address(this), feeInShares, block.number, block.timestamp);
         }
     }
 
@@ -804,8 +804,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         address recipient,
         uint256 _amount,
         uint256 _pool
-    ) internal {
-        uint256 shares;
+    ) internal returns (uint256 shares) {
         if (totalSupply() == 0) {
             shares = _amount;
         } else {
@@ -833,18 +832,21 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
         // and depositing them again
         uint256 _pool = balance().sub(totalGovernanceFee).sub(feeStrategist);
 
+        // Minted fee shares for accounting events 
+        uint256 feeInShares;
+
         // uint != is cheaper and equivalent to >
         if (totalGovernanceFee != 0) {
             address cachedTreasury = treasury;
-            _mintSharesFor(cachedTreasury, totalGovernanceFee, _pool);
-            emit PerformanceFeeGovernance(cachedTreasury, address(this), totalGovernanceFee, block.number, block.timestamp);
+            feeInShares = _mintSharesFor(cachedTreasury, totalGovernanceFee, _pool);
+            emit PerformanceFeeGovernance(cachedTreasury, address(this), feeInShares, block.number, block.timestamp);
         }
 
         if (feeStrategist != 0 && strategist != address(0)) {
             /// NOTE: adding feeGovernance backed to _pool as shares would have been issued for it.
             address cachedStrategist = strategist;
-            _mintSharesFor(cachedStrategist, feeStrategist, _pool.add(totalGovernanceFee));
-            emit PerformanceFeeStrategist(cachedStrategist, address(this), feeStrategist, block.number, block.timestamp);
+            feeInShares = _mintSharesFor(cachedStrategist, feeStrategist, _pool.add(totalGovernanceFee));
+            emit PerformanceFeeStrategist(cachedStrategist, address(this), feeInShares, block.number, block.timestamp);
         }
     }
 }

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -800,6 +800,7 @@ contract Vault is ERC20Upgradeable, SettAccessControl, PausableUpgradeable, Reen
     /// @param recipient Address to issue shares to.
     /// @param _amount Amount to issue shares on.
     /// @param _pool Pool size to use while calculating amount of shares to mint.
+    /// @return shares Amount of shares minted
     function _mintSharesFor(
         address recipient,
         uint256 _amount,

--- a/tests/unit/events/test_fee_events.py
+++ b/tests/unit/events/test_fee_events.py
@@ -115,7 +115,7 @@ def test_perf_fee_gov_event(
         )
     )
 
-    # Chek 2nd `reportAdditionalToken` route of events emitted in harvest
+    # Check 2nd `reportAdditionalToken` route of events emitted in harvest
     token_not_want.transfer(strategy, amount_harvested, {"from": deployer})
     tx = strategy.test_harvest_only_emit(
         token_not_want, amount_harvested, {"from": keeper}


### PR DESCRIPTION
The latest version of the strategy reports the fee amount based on the "underlying" token amount while for the case of withdraws and want harvests, fees are processed by minting more shares for governance and the strategist. For this reason, in the two cases mentioned above, the events were modified to report the amount in terms of "shares" or vault token.

NOTE: This is not necessary when reporting an additional token as performance fees are charged in terms of this token and this is accurately reported.

Tests were modified to reflect these changes. All tests are passing:
![image](https://user-images.githubusercontent.com/25463788/191116627-5c541c41-0c35-44aa-9cf2-82ff3c52d8f6.png)
